### PR TITLE
Bump to Krylov 0.7.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 HSL = "0.1.0, 0.2.0"
-Krylov = "~0.7.4"
+Krylov = "~0.7.6"
 LDLFactorizations = "0.8.1"
 NLPModels = "0.15, 0.16, 0.17"
 SolverCore = "0.2"


### PR DESCRIPTION
`Krylov.solve!` no longer return a pair.
Lastest Krylov.jl now requires Krylov.jl >= 0.7.6.